### PR TITLE
Fix delayed wallet provider detection

### DIFF
--- a/web/src/components/layout/AppHeader/Index.vue
+++ b/web/src/components/layout/AppHeader/Index.vue
@@ -1,20 +1,23 @@
 <script lang="ts" setup>
 import { ref, onMounted, onBeforeUnmount } from 'vue'
 import { SwitchButton, Wallet } from '@element-plus/icons-vue'
-import { isLoggedIn, getCurrentAccount, logout, hasWallet, loginWithWallet, getWalletName, watchWalletAccounts, markAccountChanged } from '@/plugins/auth'
+import { isLoggedIn, getCurrentAccount, logout, loginWithWallet, getWalletName, watchWalletAccounts, watchWalletProvider, markAccountChanged } from '@/plugins/auth'
 
 const isAuth = ref(false)
 const account = ref<string | null>(null)
 const walletInfo = ref({ present: false, name: '' })
 let stopAccountWatch: (() => void) | null = null
+let stopWalletProviderWatch: (() => void) | null = null
 
 onMounted(() => {
   isAuth.value = isLoggedIn()
   account.value = getCurrentAccount()
-  walletInfo.value = {
-    present: hasWallet(),
-    name: getWalletName()
-  }
+  stopWalletProviderWatch = watchWalletProvider((present) => {
+    walletInfo.value = {
+      present,
+      name: present ? getWalletName() : ''
+    }
+  })
 })
 
 onMounted(() => {
@@ -52,6 +55,7 @@ function handleMenuCommand(command: string) {
 }
 
 onBeforeUnmount(() => {
+  stopWalletProviderWatch?.()
   stopAccountWatch?.()
 })
 </script>

--- a/web/src/plugins/auth.ts
+++ b/web/src/plugins/auth.ts
@@ -66,6 +66,47 @@ export function hasWallet(): boolean {
   return getWalletProvider() !== null
 }
 
+export function watchWalletProvider(handler: (present: boolean) => void): () => void {
+  let stopped = false
+  let lastPresent: boolean | null = null
+  let pollCount = 0
+  let pollTimer: number | null = null
+
+  const emit = () => {
+    if (stopped) return
+    const present = hasWallet()
+    if (present === lastPresent) return
+    lastPresent = present
+    handler(present)
+  }
+
+  const poll = () => {
+    if (stopped) return
+    emit()
+    pollCount += 1
+    if (lastPresent || pollCount >= 20) return
+    pollTimer = window.setTimeout(poll, 100)
+  }
+
+  const handleProviderReady = () => {
+    emit()
+  }
+
+  window.addEventListener('ethereum#initialized', handleProviderReady)
+  window.addEventListener('eip6963:announceProvider', handleProviderReady)
+  window.dispatchEvent(new Event('eip6963:requestProvider'))
+  poll()
+
+  return () => {
+    stopped = true
+    if (pollTimer !== null) {
+      window.clearTimeout(pollTimer)
+    }
+    window.removeEventListener('ethereum#initialized', handleProviderReady)
+    window.removeEventListener('eip6963:announceProvider', handleProviderReady)
+  }
+}
+
 // 获取钱包名称
 export function getWalletName(): string {
   const provider = getWalletProvider()

--- a/web/src/views/home/Index.vue
+++ b/web/src/views/home/Index.vue
@@ -4,7 +4,7 @@ import { storeToRefs } from 'pinia'
 import { ArrowLeft, ArrowUp, Delete, Expand, Fold, FolderAdd, FolderOpened, Grid, Refresh, Upload, DocumentCopy, Share, Search, MoreFilled, Notebook, User } from '@element-plus/icons-vue'
 import { ElMessageBox } from 'element-plus'
 import { quotaApi, userApi, recycleApi, shareApi, directShareApi, assetsApi, webdavAccessKeyApi, adminUserApi, type RecycleItem, type ShareItem, type DirectShareItem, type AssetSpaceInfo, type ShareExpiryUnit, type ShareMode, type AccessKeyPermission, type WebDAVAccessKeyItem, type CreateWebDAVAccessKeyResult, type AdminUserItem } from '@/api'
-import { isLoggedIn, hasWallet, getUsername, getWalletName, getCurrentAccount, getUserPermissions, getUserCreatedAt, loginWithWallet, loginWithPassword, sendEmailCode, loginWithEmailCode, getAccountHistory, watchWalletAccounts, consumeAccountChanged } from '@/plugins/auth'
+import { isLoggedIn, getUsername, getWalletName, getCurrentAccount, getUserPermissions, getUserCreatedAt, loginWithWallet, loginWithPassword, sendEmailCode, loginWithEmailCode, getAccountHistory, watchWalletAccounts, watchWalletProvider, consumeAccountChanged } from '@/plugins/auth'
 import { parsePropfindResponse } from '@/utils/webdav'
 import { copyText } from '@/utils/clipboard'
 import { shortenAddress } from '@/utils/address'
@@ -56,7 +56,9 @@ const isMobileViewport = ref(false)
 const walletHistory = ref<string[]>([])
 const selectedWalletAccount = ref('')
 const walletRowRef = ref<HTMLElement | null>(null)
+const walletPresent = ref(false)
 let stopAccountWatch: (() => void) | null = null
+let stopWalletProviderWatch: (() => void) | null = null
 
 // 回收站相关状态
 const showRecycle = ref(false)
@@ -4133,6 +4135,9 @@ function syncWalletHistory(next?: string) {
 }
 
 onMounted(() => {
+  stopWalletProviderWatch = watchWalletProvider((present) => {
+    walletPresent.value = present
+  })
   const changed = consumeAccountChanged()
   if (changed) {
     showInfo('钱包账户已切换，请重新登录')
@@ -4147,6 +4152,7 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   window.removeEventListener('resize', syncViewportMode)
+  stopWalletProviderWatch?.()
   stopAccountWatch?.()
   clearEmailCodeTimer()
 })
@@ -4171,7 +4177,7 @@ onBeforeUnmount(() => {
         <div class="login-hero">
           <div class="login-card">
             <div class="login-section">
-              <div v-if="hasWallet() && walletHistory.length" ref="walletRowRef" class="login-wallet-row">
+              <div v-if="walletPresent && walletHistory.length" ref="walletRowRef" class="login-wallet-row">
                 <el-select
                   v-model="selectedWalletAccount"
                   placeholder="历史账户（可选）"
@@ -4197,7 +4203,7 @@ onBeforeUnmount(() => {
                 </el-button>
               </div>
               <el-button
-                v-else-if="hasWallet()"
+                v-else-if="walletPresent"
                 type="primary"
                 class="login-main-btn login-wallet-btn"
                 @click="handleWalletLogin"


### PR DESCRIPTION
## Summary
- add a wallet provider watcher that listens for ethereum#initialized and EIP-6963 announcements
- update the login page and header to use reactive wallet detection
- keep a short polling fallback for delayed extension injection

## Verification
- npm run build

Fixes #87