### PR TITLE
Prevent duplicate wallet login submissions

### DIFF
--- a/web/src/views/home/Index.vue
+++ b/web/src/views/home/Index.vue
@@ -57,6 +57,7 @@ const walletHistory = ref<string[]>([])
 const selectedWalletAccount = ref('')
 const walletRowRef = ref<HTMLElement | null>(null)
 const walletPresent = ref(false)
+const walletLoginSubmitting = ref(false)
 let stopAccountWatch: (() => void) | null = null
 let stopWalletProviderWatch: (() => void) | null = null
 
@@ -1133,12 +1134,16 @@ async function fetchAccessKeys(withLoading = false) {
 }
 
 async function handleWalletLogin() {
+  if (walletLoginSubmitting.value) return
+  walletLoginSubmitting.value = true
   try {
     const preferred = selectedWalletAccount.value.trim()
     await loginWithWallet(preferred || undefined)
     window.location.reload()
   } catch (error: any) {
     showError(error?.message || '钱包登录失败')
+  } finally {
+    walletLoginSubmitting.value = false
   }
 }
 
@@ -4183,6 +4188,7 @@ onBeforeUnmount(() => {
                   placeholder="历史账户（可选）"
                   class="login-history-select"
                   popper-class="login-history-select-popper"
+                  :disabled="walletLoginSubmitting"
                   @visible-change="handleWalletHistoryVisibleChange"
                 >
                   <el-option
@@ -4197,6 +4203,7 @@ onBeforeUnmount(() => {
                 <el-button
                   type="primary"
                   class="login-main-btn login-wallet-btn login-wallet-action-btn"
+                  :loading="walletLoginSubmitting"
                   @click="handleWalletLogin"
                 >
                   钱包登陆
@@ -4206,6 +4213,7 @@ onBeforeUnmount(() => {
                 v-else-if="walletPresent"
                 type="primary"
                 class="login-main-btn login-wallet-btn"
+                :loading="walletLoginSubmitting"
                 @click="handleWalletLogin"
               >
                 钱包登陆


### PR DESCRIPTION
## Summary
- add a wallet-login submitting state on the login page
- disable wallet account selection and show button loading while login is in progress
- prevent repeated wallet login requests while the extension is reconnecting

## Verification
- npm run build