### PR TITLE
Preserve streaming support in logger middleware

### DIFF
--- a/internal/interface/http/middleware/logger.go
+++ b/internal/interface/http/middleware/logger.go
@@ -73,12 +73,26 @@ func (m *LoggerMiddleware) getRemoteAddr(r *http.Request) string {
 // responseWriter 包装 ResponseWriter
 type responseWriter struct {
 	http.ResponseWriter
-	statusCode int
+	statusCode  int
+	wroteHeader bool
 }
 
 func (w *responseWriter) WriteHeader(statusCode int) {
+	if w.wroteHeader {
+		return
+	}
 	w.statusCode = statusCode
+	w.wroteHeader = true
 	w.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (w *responseWriter) Flush() {
+	if !w.wroteHeader {
+		w.WriteHeader(w.statusCode)
+	}
+	if flusher, ok := w.ResponseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
 }
 
 func (w *responseWriter) Unwrap() http.ResponseWriter {

--- a/internal/interface/http/middleware/logger_test.go
+++ b/internal/interface/http/middleware/logger_test.go
@@ -1,0 +1,26 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestResponseWriterSupportsFlush(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	wrapped := &responseWriter{ResponseWriter: recorder, statusCode: http.StatusOK}
+
+	flusher, ok := interface{}(wrapped).(http.Flusher)
+	if !ok {
+		t.Fatal("responseWriter should implement http.Flusher")
+	}
+
+	flusher.Flush()
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("unexpected status after flush: got=%d want=%d", recorder.Code, http.StatusOK)
+	}
+	if !wrapped.wroteHeader {
+		t.Fatal("Flush should write the pending status header")
+	}
+}


### PR DESCRIPTION
## Summary
- make the logger response writer preserve http.Flusher for streaming endpoints
- add a middleware regression test covering Flush support

## Verification
- go test ./...
- cd web && npm run build