### PR TITLE
修正active侧生成 outbox 的逻辑，避免脏数据产生

### DIFF
--- a/internal/application/service/mutation_recorder.go
+++ b/internal/application/service/mutation_recorder.go
@@ -207,6 +207,9 @@ func (r *OutboxMutationRecorder) RemovePath(ctx context.Context, fullPath string
 	if normalized == "/" {
 		return fmt.Errorf("cannot record removal of root path")
 	}
+	if isEphemeralSyncArtifactPath(normalized) {
+		return nil
+	}
 	targets, err := r.resolveTargets(ctx)
 	if err != nil {
 		return err

--- a/internal/application/service/mutation_recorder_test.go
+++ b/internal/application/service/mutation_recorder_test.go
@@ -241,9 +241,9 @@ func TestMutationRecorderMoveCopyRemoveAndEnsureDir(t *testing.T) {
 
 func TestMutationRecorderSkipsEphemeralSyncArtifacts(t *testing.T) {
 	root := t.TempDir()
-	lockDir := filepath.Join(root, "apps", "localhost-3020", "backup.__sync_mutex_v1.__sync_lock_v1")
+	lockDir := filepath.Join(root, "alice", "apps", "localhost-3020", "backup.__sync_mutex_v1.__sync_lock_v1")
 	lockFile := filepath.Join(lockDir, "lock.json")
-	txnFile := filepath.Join(root, "apps", "localhost-3020", "backup.__sync_txn_data_v1.123-abc.json")
+	txnFile := filepath.Join(root, "alice", "apps", "localhost-3020", "backup.__sync_txn_data_v1.123-abc.json")
 	if err := os.MkdirAll(lockDir, 0755); err != nil {
 		t.Fatalf("MkdirAll lockDir: %v", err)
 	}
@@ -282,6 +282,12 @@ func TestMutationRecorderSkipsEphemeralSyncArtifacts(t *testing.T) {
 	}
 	if err := recorder.CopyPath(context.Background(), txnFile, filepath.Join(root, "apps", "localhost-3020", "copy.json"), false); err != nil {
 		t.Fatalf("CopyPath txnFile: %v", err)
+	}
+	if err := recorder.RemovePath(context.Background(), lockFile, false); err != nil {
+		t.Fatalf("RemovePath lockFile: %v", err)
+	}
+	if err := recorder.RemovePath(context.Background(), lockDir, true); err != nil {
+		t.Fatalf("RemovePath lockDir: %v", err)
 	}
 	if len(repo.events) != 0 {
 		t.Fatalf("expected no outbox events for ephemeral sync artifacts, got %d", len(repo.events))

--- a/internal/application/service/webdav_service.go
+++ b/internal/application/service/webdav_service.go
@@ -371,7 +371,21 @@ func (s *WebDAVService) handleDirectDelete(
 
 func isEphemeralSyncArtifactPath(normalizedPath string) bool {
 	cleaned := path.Clean("/" + strings.TrimSpace(normalizedPath))
-	if cleaned == "/" || !strings.HasPrefix(cleaned, "/apps/") {
+	if cleaned == "/" {
+		return false
+	}
+	parts := strings.Split(strings.TrimPrefix(cleaned, "/"), "/")
+	if len(parts) < 2 {
+		return false
+	}
+	appsIndex := -1
+	for i, part := range parts {
+		if part == "apps" {
+			appsIndex = i
+			break
+		}
+	}
+	if appsIndex < 0 || len(parts) <= appsIndex+1 {
 		return false
 	}
 

--- a/internal/application/service/webdav_service_replication_test.go
+++ b/internal/application/service/webdav_service_replication_test.go
@@ -291,8 +291,12 @@ func TestShouldHardDeleteSyncArtifact(t *testing.T) {
 		{path: "/apps/localhost-3020/backup.__sync_mutex_v1.__sync_lock_v1", want: true},
 		{path: "/apps/localhost-3020/backup.__sync_mutex_v1.__sync_lock_v1/lock.json", want: true},
 		{path: "/apps/localhost-3020/backup.__sync_txn_data_v1.123-abc.json", want: true},
+		{path: "/alice/apps/localhost-3020/backup.__sync_mutex_v1.__sync_lock_v1", want: true},
+		{path: "/alice/apps/localhost-3020/backup.__sync_mutex_v1.__sync_lock_v1/lock.json", want: true},
+		{path: "/alice/apps/localhost-3020/backup.__sync_txn_data_v1.123-abc.json", want: true},
 		{path: "/apps/localhost-3020/backup.json", want: false},
 		{path: "/personal/backup.__sync_txn_data_v1.123-abc.json", want: false},
+		{path: "/alice/personal/backup.__sync_txn_data_v1.123-abc.json", want: false},
 		{path: "/apps/localhost-3020/notes/lock.json", want: false},
 	}
 


### PR DESCRIPTION
现在主备节点之间一直有脏数据产生，导致同步受到阻碍