### PR TITLE
Focus pending wallet approval on repeat login

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@vueuse/core": "^13.1.0",
-        "@yeying-community/web3-bs": "^1.0.10",
+        "@yeying-community/web3-bs": "^1.0.11",
         "buffer": "^6.0.3",
         "docx-preview": "^0.3.7",
         "element-plus": "^2.9.2",
@@ -1927,9 +1927,9 @@
       }
     },
     "node_modules/@yeying-community/web3-bs": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmmirror.com/@yeying-community/web3-bs/-/web3-bs-1.0.10.tgz",
-      "integrity": "sha512-d/siblkHug+G0UvsPTFNP8IKWWjVDgdlulW6/3y/FyLBL5kGV6A4B8lvuDnLfCwclp5D89PwsM3hq7U0Fu/MLg==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmmirror.com/@yeying-community/web3-bs/-/web3-bs-1.0.11.tgz",
+      "integrity": "sha512-Tgs/1/buFDBplU5MhF+tkoXQzDsxXCYUtdEeVddRf12HT1WYPj5mSgvqbDeR8s8X0zyosq3M7VTxbfeWR44McA==",
       "license": "ISC"
     },
     "node_modules/acorn": {

--- a/web/package.json
+++ b/web/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@vueuse/core": "^13.1.0",
-    "@yeying-community/web3-bs": "^1.0.10",
+    "@yeying-community/web3-bs": "^1.0.11",
     "buffer": "^6.0.3",
     "docx-preview": "^0.3.7",
     "element-plus": "^2.9.2",

--- a/web/src/components/layout/AppHeader/Index.vue
+++ b/web/src/components/layout/AppHeader/Index.vue
@@ -2,11 +2,12 @@
 import { computed, ref, onMounted, onBeforeUnmount } from 'vue'
 import { Bell, SwitchButton, Wallet } from '@element-plus/icons-vue'
 import { notificationApi, type AdminNotificationCreatePayload, type NotificationItem, type NotificationPreferenceItem } from '@/api'
-import { isLoggedIn, getCurrentAccount, logout, loginWithWallet, getWalletName, watchWalletAccounts, watchWalletProvider, markAccountChanged } from '@/plugins/auth'
+import { isLoggedIn, getCurrentAccount, logout, loginWithWallet, focusPendingWalletApproval, getWalletName, watchWalletAccounts, watchWalletProvider, markAccountChanged } from '@/plugins/auth'
 
 const isAuth = ref(false)
 const account = ref<string | null>(null)
 const walletInfo = ref({ present: false, name: '' })
+const walletConnectSubmitting = ref(false)
 const notificationOpen = ref(false)
 const notificationLoading = ref(false)
 const notificationTab = ref<'user' | 'admin'>('user')
@@ -68,11 +69,18 @@ onMounted(() => {
 })
 
 async function handleConnect() {
+  if (walletConnectSubmitting.value) {
+    await focusPendingWalletApproval()
+    return
+  }
+  walletConnectSubmitting.value = true
   try {
     await loginWithWallet()
     window.location.reload()
   } catch (error) {
     console.error('连接失败:', error)
+  } finally {
+    walletConnectSubmitting.value = false
   }
 }
 
@@ -351,7 +359,7 @@ onBeforeUnmount(() => {
           @click="handleConnect"
         >
           <el-icon><Wallet /></el-icon>
-          连接钱包
+          {{ walletConnectSubmitting ? '查看钱包弹窗' : '连接钱包' }}
         </el-button>
         <span v-else class="no-wallet">未检测到钱包</span>
       </template>

--- a/web/src/plugins/auth.ts
+++ b/web/src/plugins/auth.ts
@@ -8,6 +8,7 @@ import {
   setAccessToken,
   watchAccounts,
   watchProvider,
+  focusPendingApproval,
   getWalletErrorMessage,
   isUserRejectedWalletAction,
   classifyWalletError,
@@ -136,6 +137,19 @@ export async function watchWalletAccounts(handler: (payload: { account: string |
     }
     handler({ account: account || null, accounts })
   })
+}
+
+export async function focusPendingWalletApproval(): Promise<boolean> {
+  const provider = currentWalletProvider || await getProvider()
+  if (!provider) return false
+
+  try {
+    const result = await focusPendingApproval(provider)
+    return result.focused
+  } catch (error) {
+    console.warn('聚焦钱包待确认窗口失败:', error)
+    return false
+  }
 }
 
 // 钱包登录流程

--- a/web/src/views/home/Index.vue
+++ b/web/src/views/home/Index.vue
@@ -4,7 +4,7 @@ import { storeToRefs } from 'pinia'
 import { ArrowLeft, ArrowUp, Delete, Expand, Fold, FolderAdd, FolderOpened, Grid, Refresh, Upload, DocumentCopy, Share, Search, MoreFilled, Notebook, User } from '@element-plus/icons-vue'
 import { ElMessageBox } from 'element-plus'
 import { quotaApi, userApi, recycleApi, shareApi, directShareApi, assetsApi, webdavAccessKeyApi, adminUserApi, type RecycleItem, type ShareItem, type DirectShareItem, type AssetSpaceInfo, type ShareExpiryUnit, type ShareMode, type AccessKeyPermission, type WebDAVAccessKeyItem, type CreateWebDAVAccessKeyResult, type AdminUserItem } from '@/api'
-import { isLoggedIn, getUsername, getWalletName, getCurrentAccount, getUserPermissions, getUserCreatedAt, loginWithWallet, loginWithPassword, sendEmailCode, loginWithEmailCode, getAccountHistory, watchWalletAccounts, watchWalletProvider, consumeAccountChanged } from '@/plugins/auth'
+import { isLoggedIn, getUsername, getWalletName, getCurrentAccount, getUserPermissions, getUserCreatedAt, loginWithWallet, focusPendingWalletApproval, loginWithPassword, sendEmailCode, loginWithEmailCode, getAccountHistory, watchWalletAccounts, watchWalletProvider, consumeAccountChanged } from '@/plugins/auth'
 import { parsePropfindResponse } from '@/utils/webdav'
 import { copyText } from '@/utils/clipboard'
 import { shortenAddress } from '@/utils/address'
@@ -1134,7 +1134,10 @@ async function fetchAccessKeys(withLoading = false) {
 }
 
 async function handleWalletLogin() {
-  if (walletLoginSubmitting.value) return
+  if (walletLoginSubmitting.value) {
+    await focusPendingWalletApproval()
+    return
+  }
   walletLoginSubmitting.value = true
   try {
     const preferred = selectedWalletAccount.value.trim()
@@ -4207,20 +4210,18 @@ onBeforeUnmount(() => {
                 <el-button
                   type="primary"
                   class="login-main-btn login-wallet-btn login-wallet-action-btn"
-                  :loading="walletLoginSubmitting"
                   @click="handleWalletLogin"
                 >
-                  钱包登陆
+                  {{ walletLoginSubmitting ? '查看钱包弹窗' : '钱包登陆' }}
                 </el-button>
               </div>
               <el-button
                 v-else-if="walletPresent"
                 type="primary"
                 class="login-main-btn login-wallet-btn"
-                :loading="walletLoginSubmitting"
                 @click="handleWalletLogin"
               >
-                钱包登陆
+                {{ walletLoginSubmitting ? '查看钱包弹窗' : '钱包登陆' }}
               </el-button>
               <div v-else class="login-warning">未检测到钱包插件</div>
             </div>


### PR DESCRIPTION
## Summary
- upgrade @yeying-community/web3-bs to 1.0.11
- expose a warehouse auth helper for focusing pending wallet approval windows
- keep wallet login/connect buttons clickable during an in-flight request so repeat clicks bring the existing wallet popup to front

## Tests
- cd web && npm run build