### PR TITLE
fix: harden notification migrations and group invites

### DIFF
--- a/config.yaml.template
+++ b/config.yaml.template
@@ -130,6 +130,12 @@ cors:
   enabled: true
   credentials: true
   allowed_origins:
+    # Tauri desktop app origin. Required when the packaged Chat app calls
+    # Warehouse/WebDAV directly for cloud storage checks and sync.
+    - "tauri://localhost"
+    # Central UCAN desktop callback origin. Keep this only if the callback
+    # flow may call Warehouse before returning to the main Tauri window.
+    - "http://tauri.localhost"
     - "http://localhost:3000"
     - "https://your-domain.com"
   allowed_methods:

--- a/docs/数据模型.md
+++ b/docs/数据模型.md
@@ -117,6 +117,8 @@ erDiagram
 - **share_items**：公开分享记录，按 token 访问。
 - **internal_share_items / internal_share_audiences**：站内共享主表与受众表，统一承载单地址、动态分组受众和全员共享。
 - **address_groups / group_members**：共享分组与成员关系；`address_groups` 为历史表名，业务语义为分组管理。
+- **notifications / notification_preferences**：用户消息、管理员公告、分组邀请通知及用户消息偏好。
+- **schema_migrations**：记录已经应用的数据库结构升级版本；迁移使用 PostgreSQL advisory lock，避免多个实例同时修改 Schema。
 
 ## 升级提示（分享相关）
 
@@ -138,3 +140,4 @@ erDiagram
 - `recycle_items.hash` 唯一
 - `address_groups(user_id, name)` 唯一
 - `group_members(group_id, wallet_address)` 唯一
+- `notifications(dedupe_key)` 在 `dedupe_key IS NOT NULL` 时唯一，用于通知幂等写入；启动迁移会处理历史重复值并校验索引定义

--- a/internal/application/service/notification_service.go
+++ b/internal/application/service/notification_service.go
@@ -155,11 +155,17 @@ func (s *NotificationService) EnsureGroupInviteNotifications(ctx context.Context
 			continue
 		}
 		groupName := ""
+		inviterName := ""
 		grp, err := s.groupRepo.GetVisibleGroupByID(ctx, u.ID, u.WalletAddress, member.GroupID)
 		if err == nil && grp != nil {
 			groupName = grp.Name
+			if s.userRepo != nil {
+				if inviter, findErr := s.userRepo.FindByID(ctx, grp.UserID); findErr == nil && inviter != nil {
+					inviterName = displayUserName(inviter)
+				}
+			}
 		}
-		if err := s.upsertGroupInvite(ctx, u.ID, groupName, member.ID); err != nil {
+		if err := s.upsertGroupInvite(ctx, u.ID, inviterName, groupName, member.ID); err != nil {
 			return err
 		}
 	}
@@ -174,7 +180,7 @@ func (s *NotificationService) NotifyGroupInvite(ctx context.Context, inviter *us
 	if err != nil || target == nil || target.ID == inviter.ID {
 		return
 	}
-	if err := s.upsertGroupInvite(ctx, target.ID, groupName, member.ID); err != nil && s.logger != nil {
+	if err := s.upsertGroupInvite(ctx, target.ID, displayUserName(inviter), groupName, member.ID); err != nil && s.logger != nil {
 		s.logger.Warn("failed to create group invite notification",
 			zap.String("member_id", member.ID),
 			zap.Error(err))
@@ -413,10 +419,15 @@ func (s *NotificationService) NotifyShareCreated(ctx context.Context, owner *use
 	}
 }
 
-func (s *NotificationService) upsertGroupInvite(ctx context.Context, userID, groupName, memberID string) error {
+func (s *NotificationService) upsertGroupInvite(ctx context.Context, userID, inviterName, groupName, memberID string) error {
+	inviterName = strings.TrimSpace(inviterName)
 	groupName = strings.TrimSpace(groupName)
 	if groupName == "" {
 		groupName = "未命名分组"
+	}
+	content := fmt.Sprintf("你被邀请加入分组「%s」，请确认是否加入。", groupName)
+	if inviterName != "" {
+		content = fmt.Sprintf("%s 邀请你加入分组「%s」，请确认是否加入。", inviterName, groupName)
 	}
 	memberID = strings.TrimSpace(memberID)
 	if userID == "" || memberID == "" {
@@ -427,11 +438,21 @@ func (s *NotificationService) upsertGroupInvite(ctx context.Context, userID, gro
 		RecipientRole:   notification.RecipientRoleUser,
 		Type:            notification.TypeGroupInvite,
 		Title:           "收到分组邀请",
-		Content:         fmt.Sprintf("你被邀请加入分组「%s」，请确认是否加入。", groupName),
+		Content:         content,
 		Severity:        notification.SeverityInfo,
 		ActionURL:       groupInviteActionURL(memberID),
 		DedupeKey:       fmt.Sprintf("group:invite:%s:%s", memberID, userID),
 	})
+}
+
+func displayUserName(u *user.User) string {
+	if u == nil {
+		return ""
+	}
+	if name := strings.TrimSpace(u.Username); name != "" {
+		return name
+	}
+	return strings.TrimSpace(u.WalletAddress)
 }
 
 func isPendingInviteForUser(u *user.User, member *group.Member) bool {

--- a/internal/application/service/notification_service_test.go
+++ b/internal/application/service/notification_service_test.go
@@ -66,6 +66,52 @@ func TestNotificationServiceEnsuresPendingGroupInviteForCurrentUser(t *testing.T
 	if !strings.Contains(item.Content, "test_01") {
 		t.Fatalf("notification content = %q, want group name", item.Content)
 	}
+	if !strings.Contains(item.Content, owner.Username) {
+		t.Fatalf("notification content = %q, want inviter username", item.Content)
+	}
+}
+
+func TestNotificationServiceDismissesInviteAfterApproveAndReject(t *testing.T) {
+	ctx := context.Background()
+	for _, accepted := range []bool{true, false} {
+		t.Run(map[bool]string{true: "approve", false: "reject"}[accepted], func(t *testing.T) {
+			groupRepo := newFakeGroupRepository()
+			notificationRepo := newFakeNotificationRepository()
+			userRepo := newTestUserRepo()
+			svc := NewNotificationService(notificationRepo, userRepo, nil)
+			svc.SetGroupRepository(groupRepo)
+			groupSvc := NewGroupService(groupRepo, userRepo)
+			groupSvc.SetNotificationService(svc)
+
+			owner := &user.User{ID: "owner-user", Username: "owner", WalletAddress: "0x1111111111111111111111111111111111111111"}
+			invited := &user.User{ID: "invited-user", Username: "invited", WalletAddress: "0x2222222222222222222222222222222222222222"}
+			_ = userRepo.Save(ctx, owner)
+			_ = userRepo.Save(ctx, invited)
+			grp, _ := groupSvc.CreateGroup(ctx, owner, "team")
+			member, err := groupSvc.CreateMember(ctx, owner, CreateMemberInput{Target: invited.WalletAddress, GroupID: grp.ID})
+			if err != nil {
+				t.Fatalf("CreateMember() error = %v", err)
+			}
+			if _, err := svc.UnreadCountForUser(ctx, invited); err != nil {
+				t.Fatalf("UnreadCountForUser() error = %v", err)
+			}
+			if accepted {
+				err = groupSvc.ApproveMember(ctx, invited, member.ID, invited.Username)
+			} else {
+				err = groupSvc.RejectMember(ctx, invited, member.ID)
+			}
+			if err != nil {
+				t.Fatalf("respond invite error = %v", err)
+			}
+			items, err := svc.ListForUser(ctx, invited, 20)
+			if err != nil {
+				t.Fatalf("ListForUser() error = %v", err)
+			}
+			if len(items) != 0 {
+				t.Fatalf("ListForUser() returned %d active notifications, want 0", len(items))
+			}
+		})
+	}
 }
 
 type fakeNotificationRepository struct {

--- a/internal/infrastructure/database/postgres.go
+++ b/internal/infrastructure/database/postgres.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 
 	_ "github.com/lib/pq"
@@ -14,6 +15,12 @@ import (
 type PostgresDB struct {
 	DB *sql.DB
 }
+
+const (
+	schemaMigrationLockID              int64 = 846273910527
+	notificationDedupeMigrationVersion       = "2026072601"
+	notificationDedupeMigrationName          = "notification_dedupe_partial_unique_index"
+)
 
 // NewPostgresDB 创建 PostgreSQL 数据库连接
 func NewPostgresDB(cfg config.DatabaseConfig) (*PostgresDB, error) {
@@ -505,25 +512,6 @@ func (p *PostgresDB) Migrate(ctx context.Context) error {
 			WHERE recipient_user_id IS NOT NULL`,
 		`CREATE INDEX IF NOT EXISTS idx_notifications_role_unread
 			ON notifications(recipient_role, read_at)`,
-		`WITH duplicate_notifications AS (
-			SELECT
-				id,
-				dedupe_key,
-				ROW_NUMBER() OVER (
-					PARTITION BY dedupe_key
-					ORDER BY created_at DESC, id DESC
-				) AS row_number
-			FROM notifications
-			WHERE dedupe_key IS NOT NULL
-		)
-		UPDATE notifications n
-		SET dedupe_key = n.dedupe_key || ':legacy:' || n.id
-		FROM duplicate_notifications d
-		WHERE n.id = d.id AND d.row_number > 1`,
-		`DROP INDEX IF EXISTS idx_notifications_dedupe_key`,
-		`CREATE UNIQUE INDEX IF NOT EXISTS idx_notifications_dedupe_key
-			ON notifications(dedupe_key)
-			WHERE dedupe_key IS NOT NULL`,
 		`CREATE INDEX IF NOT EXISTS idx_notification_preferences_user
 			ON notification_preferences(user_id)`,
 
@@ -642,10 +630,34 @@ func (p *PostgresDB) Migrate(ctx context.Context) error {
 	}
 	defer tx.Rollback()
 
+	// 多实例共用数据库时只允许一个实例执行结构升级，其他实例等待事务完成。
+	if _, err := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock($1)`, schemaMigrationLockID); err != nil {
+		return fmt.Errorf("failed to acquire schema migration lock: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS schema_migrations (
+		version VARCHAR(50) PRIMARY KEY,
+		name VARCHAR(255) NOT NULL,
+		applied_at TIMESTAMP NOT NULL DEFAULT NOW()
+	)`); err != nil {
+		return fmt.Errorf("failed to initialize schema migration history: %w", err)
+	}
+
 	for _, query := range queries {
 		if _, err := tx.ExecContext(ctx, query); err != nil {
 			return fmt.Errorf("failed to execute migration query: %w", err)
 		}
+	}
+
+	if err := ensureNotificationDedupeConstraint(ctx, tx); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO schema_migrations (version, name)
+		VALUES ($1, $2)
+		ON CONFLICT (version) DO UPDATE SET name = EXCLUDED.name`,
+		notificationDedupeMigrationVersion,
+		notificationDedupeMigrationName,
+	); err != nil {
+		return fmt.Errorf("failed to record notification schema migration: %w", err)
 	}
 
 	if err := tx.Commit(); err != nil {
@@ -653,4 +665,95 @@ func (p *PostgresDB) Migrate(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+type notificationConstraintQuerier interface {
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
+type notificationConstraintDB interface {
+	notificationConstraintQuerier
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+}
+
+func ensureNotificationDedupeConstraint(ctx context.Context, db notificationConstraintDB) error {
+	valid, err := notificationDedupeConstraintValid(ctx, db)
+	if err != nil {
+		return fmt.Errorf("failed to inspect notification dedupe constraint: %w", err)
+	}
+	if valid {
+		return nil
+	}
+
+	queries := []string{
+		`WITH duplicate_notifications AS (
+			SELECT
+				id,
+				dedupe_key,
+				ROW_NUMBER() OVER (
+					PARTITION BY dedupe_key
+					ORDER BY created_at DESC, id DESC
+				) AS row_number
+			FROM notifications
+			WHERE dedupe_key IS NOT NULL
+		)
+		UPDATE notifications n
+		SET dedupe_key = n.dedupe_key || ':legacy:' || n.id
+		FROM duplicate_notifications d
+		WHERE n.id = d.id AND d.row_number > 1`,
+		`DROP INDEX IF EXISTS idx_notifications_dedupe_key`,
+		`CREATE UNIQUE INDEX idx_notifications_dedupe_key
+			ON notifications(dedupe_key)
+			WHERE dedupe_key IS NOT NULL`,
+	}
+	for _, query := range queries {
+		if _, err := db.ExecContext(ctx, query); err != nil {
+			return fmt.Errorf("failed to repair notification dedupe constraint: %w", err)
+		}
+	}
+	return verifyNotificationDedupeConstraint(ctx, db)
+}
+
+func notificationDedupeConstraintValid(ctx context.Context, db notificationConstraintQuerier) (bool, error) {
+	unique, columnName, predicate, err := loadNotificationDedupeConstraint(ctx, db)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return false, nil
+		}
+		return false, err
+	}
+	normalizedPredicate := strings.ToLower(strings.Join(strings.Fields(predicate), " "))
+	return unique && columnName == "dedupe_key" && strings.Contains(normalizedPredicate, "dedupe_key") && strings.Contains(normalizedPredicate, "is not null"), nil
+}
+
+// verifyNotificationDedupeConstraint prevents the service from becoming ready with a
+// notification schema that cannot satisfy UpsertByDedupeKey's ON CONFLICT target.
+func verifyNotificationDedupeConstraint(ctx context.Context, db notificationConstraintQuerier) error {
+	valid, err := notificationDedupeConstraintValid(ctx, db)
+	if err != nil {
+		return fmt.Errorf("failed to verify notification dedupe constraint: %w", err)
+	}
+	if !valid {
+		return fmt.Errorf("notification dedupe constraint is incompatible: expected UNIQUE (dedupe_key) WHERE dedupe_key IS NOT NULL")
+	}
+	return nil
+}
+
+func loadNotificationDedupeConstraint(ctx context.Context, db notificationConstraintQuerier) (bool, string, string, error) {
+	var unique bool
+	var columnName string
+	var predicate string
+	err := db.QueryRowContext(ctx, `
+		SELECT i.indisunique, a.attname, COALESCE(pg_get_expr(i.indpred, i.indrelid), '')
+		FROM pg_class idx
+		JOIN pg_index i ON i.indexrelid = idx.oid
+		JOIN pg_class tbl ON tbl.oid = i.indrelid
+		JOIN pg_namespace ns ON ns.oid = tbl.relnamespace
+		JOIN pg_attribute a ON a.attrelid = tbl.oid AND a.attnum = i.indkey[0]
+		WHERE ns.nspname = current_schema()
+			AND tbl.relname = 'notifications'
+			AND idx.relname = 'idx_notifications_dedupe_key'
+			AND i.indnatts = 1
+	`).Scan(&unique, &columnName, &predicate)
+	return unique, columnName, predicate, err
 }

--- a/internal/infrastructure/database/postgres_test.go
+++ b/internal/infrastructure/database/postgres_test.go
@@ -1,0 +1,87 @@
+package database
+
+import (
+	"context"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestVerifyNotificationDedupeConstraintAcceptsPartialUniqueIndex(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT i.indisunique, a.attname, COALESCE(pg_get_expr(i.indpred, i.indrelid), '')")).
+		WillReturnRows(sqlmock.NewRows([]string{"indisunique", "attname", "predicate"}).
+			AddRow(true, "dedupe_key", "(dedupe_key IS NOT NULL)"))
+
+	if err := verifyNotificationDedupeConstraint(context.Background(), db); err != nil {
+		t.Fatalf("verifyNotificationDedupeConstraint() error = %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestVerifyNotificationDedupeConstraintRejectsNonUniqueIndex(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT i.indisunique, a.attname, COALESCE(pg_get_expr(i.indpred, i.indrelid), '')")).
+		WillReturnRows(sqlmock.NewRows([]string{"indisunique", "attname", "predicate"}).
+			AddRow(false, "dedupe_key", "(dedupe_key IS NOT NULL)"))
+
+	if err := verifyNotificationDedupeConstraint(context.Background(), db); err == nil {
+		t.Fatal("verifyNotificationDedupeConstraint() error = nil, want incompatible constraint")
+	}
+}
+
+func TestEnsureNotificationDedupeConstraintSkipsValidIndex(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT i.indisunique, a.attname, COALESCE(pg_get_expr(i.indpred, i.indrelid), '')")).
+		WillReturnRows(sqlmock.NewRows([]string{"indisunique", "attname", "predicate"}).
+			AddRow(true, "dedupe_key", "(dedupe_key IS NOT NULL)"))
+
+	if err := ensureNotificationDedupeConstraint(context.Background(), db); err != nil {
+		t.Fatalf("ensureNotificationDedupeConstraint() error = %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestEnsureNotificationDedupeConstraintRepairsMissingIndex(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	indexQuery := regexp.QuoteMeta("SELECT i.indisunique, a.attname, COALESCE(pg_get_expr(i.indpred, i.indrelid), '')")
+	mock.ExpectQuery(indexQuery).WillReturnRows(sqlmock.NewRows([]string{"indisunique", "attname", "predicate"}))
+	mock.ExpectExec("WITH duplicate_notifications AS").WillReturnResult(sqlmock.NewResult(0, 2))
+	mock.ExpectExec("DROP INDEX IF EXISTS idx_notifications_dedupe_key").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("CREATE UNIQUE INDEX idx_notifications_dedupe_key").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery(indexQuery).
+		WillReturnRows(sqlmock.NewRows([]string{"indisunique", "attname", "predicate"}).
+			AddRow(true, "dedupe_key", "(dedupe_key IS NOT NULL)"))
+
+	if err := ensureNotificationDedupeConstraint(context.Background(), db); err != nil {
+		t.Fatalf("ensureNotificationDedupeConstraint() error = %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}

--- a/web/src/components/layout/AppHeader/Index.vue
+++ b/web/src/components/layout/AppHeader/Index.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { computed, ref, watch, onMounted, onBeforeUnmount } from 'vue'
 import { Bell, Check, Close, Notebook, SwitchButton, Wallet } from '@element-plus/icons-vue'
-import { ElMessageBox } from 'element-plus'
+import { ElMessage, ElMessageBox } from 'element-plus'
 import { storeToRefs } from 'pinia'
 import { groupApi, notificationApi, userApi, type AdminNotificationCreatePayload, type NotificationItem, type NotificationPreferenceItem } from '@/api'
 import { AUTH_CHANGED_EVENT, isLoggedIn, getCurrentAccount, logout, loginWithWallet, focusPendingWalletApproval, getWalletName, watchWalletAccounts, watchWalletProvider } from '@/plugins/auth'
@@ -378,8 +378,13 @@ async function respondGroupInvite(item: NotificationItem, accepted: boolean, eve
     notifications.value = notifications.value.filter(current => current.id !== item.id)
     await refreshUnreadCounts()
     window.dispatchEvent(new CustomEvent('warehouse:groups-refresh'))
-  } catch (error) {
+    ElMessage({ message: accepted ? '已加入分组' : '已拒绝分组邀请', type: 'success' })
+  } catch (error: any) {
     console.warn(accepted ? '确认分组邀请失败:' : '拒绝分组邀请失败:', error)
+    ElMessage({
+      message: error?.message || (accepted ? '确认分组邀请失败' : '拒绝分组邀请失败'),
+      type: 'error'
+    })
   } finally {
     const next = { ...notificationActionLoading.value }
     delete next[item.id]


### PR DESCRIPTION
## Summary

- serialize database schema upgrades with a PostgreSQL advisory lock and record the notification migration
- repair and validate the partial unique notification dedupe index before the service becomes ready
- include the inviter in group invitation notifications and close notifications after approval or rejection
- show clear success and error feedback for group invitation actions in the header

## Validation

- go test ./...
- npm run test:run -- --passWithNoTests
- npm run build
- npm run openapi:check
- git diff --check